### PR TITLE
Allowing images to be more easily imported from node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Minifies images in production mode
 
 #### Options
 
- * `src`
+ * `src` - can take an array, and handle `node_modules` paths. `src: ['x', 'y']` for example, translates to `['root/x', 'node_modules/x', 'root/y', 'node_modules/y']` (where earlier paths takes priority)
  * `dest`
 
 ### svg

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinion-pipeline",
   "description": "An opinionated pipeline, modelled after the Rails asset pipeline. Designed for the benefits of speed, and access to CommonJS modules",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "./index.js",
   "bin": {
     "pinion": "./bin/index.js"

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -12,8 +12,18 @@ var imagemin = require('../lib/gulpImagemin');
 module.exports = function(config) {
   if(!config.tasks.images) return;
 
+  var relativePath = config.tasks.images.src;
+  if(Array.isArray(config.tasks.images.src)) {
+    relativePath = '{' + relativePath.join(',') + '}';
+  }
+
   var paths = {
-    src: path.join(config.root.src, config.tasks.images.src, '/**'),
+    src: [
+      path.join(config.root.src, relativePath, '/**'),
+
+      // Search for images in the package's node_modules too
+      path.join(process.cwd(), 'node_modules', relativePath, '/**')
+    ],
     dest: path.join(config.root.dest, config.tasks.images.dest)
   };
 

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -12,18 +12,27 @@ var imagemin = require('../lib/gulpImagemin');
 module.exports = function(config) {
   if(!config.tasks.images) return;
 
-  var relativePath = config.tasks.images.src;
-  if(Array.isArray(config.tasks.images.src)) {
-    relativePath = '{' + relativePath.join(',') + '}';
+  var relativePathArr = config.tasks.images.src;
+  if(!Array.isArray(relativePathArr)) {
+    relativePathArr = [relativePathArr]
   }
 
-  var paths = {
-    src: [
-      path.join(config.root.src, relativePath, '/**'),
+  var imagesSrc = relativePathArr.reduceRight(function(soFar, relativePath) {
+    var rootImagePath = path.join(config.root.src, relativePath, '/**');
+    // Search for images in the package's node_modules too
+    var npmImagePath = path.join(process.cwd(), 'node_modules', relativePath, '/**');
 
-      // Search for images in the package's node_modules too
-      path.join(process.cwd(), 'node_modules', relativePath, '/**')
-    ],
+    // Order is important, it denotes merge priority (sooner is higher)
+    var imagePathArr = [
+      rootImagePath,
+      npmImagePath
+    ];
+
+    return imagePathArr.concat(soFar)
+  });
+
+  var paths = {
+    src: imagesSrc,
     dest: path.join(config.root.dest, config.tasks.images.dest)
   };
 

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
 
   var relativePathArr = config.tasks.images.src;
   if(!Array.isArray(relativePathArr)) {
-    relativePathArr = [relativePathArr]
+    relativePathArr = [relativePathArr];
   }
 
   var imagesSrc = relativePathArr.reduceRight(function(soFar, relativePath) {
@@ -28,7 +28,7 @@ module.exports = function(config) {
       npmImagePath
     ];
 
-    return imagePathArr.concat(soFar)
+    return imagePathArr.concat(soFar);
   });
 
   var paths = {

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -17,7 +17,8 @@ module.exports = function(config) {
     watchableTasks.forEach(function(taskName) {
       var task = config.tasks[taskName];
       if(task) {
-        var glob = path.join(config.root.src, task.src, '**/*');
+        var taskSrc = Array.isArray(task.src) ? '{' + task.src.join(',') + '}' : task.src;
+        var glob = path.join(config.root.src, taskSrc, '**/*');
         watch(glob, { usePolling: true }, function() {
           gulp.start(taskName);
         });


### PR DESCRIPTION
This will allow the following sort of thing in a pinionfile:

```
images: {
  src: [
    "base/img/path",
    "some_npm_module/imgs"
  ],
  dest: ""
}
```