### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ pinion's CLI is designed to mimic gulp.
   * `pinion x y z` runs the tasks `x`, `y`, and then `z`
 
 # Sample `pinionfile.js`
+Not much is required to get going with simple tasks
+```js
+module.exports = {
+  tasks: {
+    // build from src/javascripts/app.js to bin/bundle.js
+    js: {
+      entries: {
+        bundle: ['app.js']
+      }
+    },
+
+    // build from src/stylesheets/*.{scss,css} to bin/*.css
+    css: {},
+
+    // build from src/images/* to bin/*
+    images: {}
+  }
+}
+```
+
+
+But we can be more verbose for greater control
 
 ```js
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@
 var gulp = require('gulp');
 var gulpSequence = require('gulp-sequence');
 var requireDir = require('require-dir');
+var objectAssign = require('object-assign');
 
 function passConfigRecursive(taskConstrucs, config) {
   Object.keys(taskConstrucs).forEach(function(key) {
@@ -37,7 +38,12 @@ function passConfigRecursive(taskConstrucs, config) {
 
 module.exports = {
   start: function(toRun, config) {
-    config = config || {};
+    config = objectAssign({
+      root: {
+        src: 'src',
+        dest: 'bin'
+      }
+    }, config);
 
     // Load all of the tasks that we might need to run
     var taskConstrucs = requireDir('./tasks', { recurse: true });

--- a/lib/handleErrors.js
+++ b/lib/handleErrors.js
@@ -7,7 +7,4 @@ module.exports = function(errorObject) {
     var notify = require('gulp-notify');
     notify.onError(errorObject.toString().split(': ').join(':\n')).apply(this, arguments);
   }
-
-  // Keep gulp from hanging on this task
-  if (typeof this.emit === 'function') this.emit('end');
 };

--- a/lib/webpackBaseConfig.js
+++ b/lib/webpackBaseConfig.js
@@ -114,7 +114,18 @@ module.exports = function(taskConfig, rootConfig) {
         },
         {
           test: /\.css$/,
-          loader: 'style!css'
+          loaders: [
+            'style',
+            'css?modules&localIdentName=[local]___[hash:base64:5]'
+          ]
+        },
+        {
+          test: /\.scss$/,
+          loaders: [
+            'style',
+            'css?modules&localIdentName=[local]___[hash:base64:5]',
+            'sass'
+          ]
         }
       ])
     },

--- a/package.json
+++ b/package.json
@@ -49,15 +49,16 @@
     "liftoff": "^2.2.1",
     "merge-stream": "^1.0.0",
     "minimist": "^1.2.0",
-    "npm-sass": "^1.2.0",
+    "node-sass": "^3.10.1",
     "object-assign": "^4.1.0",
     "readable-stream": "^2.1.5",
     "require-dir": "^0.3.0",
+    "sass-loader": "^4.0.0",
     "script-loader": "^0.7.0",
     "semver": "^5.1.0",
     "style-loader": "^0.13.1",
     "tildify": "^1.2.0",
-    "webpack": "^1.13.0"
+    "webpack": "^1.13.2"
   },
   "devDependencies": {
     "gulp-jshint": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinion-pipeline",
   "description": "An opinionated pipeline, modelled after the Rails asset pipeline. Designed for the benefits of speed, and access to CommonJS modules",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "./index.js",
   "bin": {
     "pinion": "./bin/index.js"

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -15,7 +15,7 @@ var cookTask = require('../lib/cookTask');
 var cookTaskConfig = require('../lib/cookTaskConfig');
 
 var defaultTaskConfig = {
-  src: '.',
+  src: 'stylesheets',
   dest: '.',
   extensions: ['css', 'scss']
 };
@@ -28,7 +28,7 @@ module.exports = function(config) {
 
   var rawTask = function (options) {
     gutil.log('Compiling SASS from ' + JSON.stringify(options.src));
-    var sassConfig = options.config.sass;
+    var sassConfig = options.config.sass || {};
 
     // Allow `@import` calls to search the package's node_modules directory
     sassConfig.includePaths = ["node_modules"];

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -5,7 +5,7 @@ var gutil = require('gulp-util');
 var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
 var autoprefixer = require('gulp-autoprefixer');
-var npmSass = require('npm-sass');
+var nodeSass = require('node-sass');
 var cleanCSS = require('gulp-clean-css');
 var handleErrors = require('../lib/handleErrors');
 var env = require('../lib/env');
@@ -31,7 +31,7 @@ module.exports = function(config) {
     var sassConfig = options.config.sass;
 
     // Allow `@import` calls to search the package's node_modules directory
-    sassConfig.importer = npmSass.importer;
+    sassConfig.includePaths = ["node_modules"];
 
     return gulp.src(options.src)
       .pipe(debug({ title: 'css' }))

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
     var sassConfig = options.config.sass || {};
 
     // Allow `@import` calls to search the package's node_modules directory
-    sassConfig.includePaths = ["node_modules"];
+    sassConfig.includePaths = ['node_modules'];
 
     return gulp.src(options.src)
       .pipe(debug({ title: 'css' }))

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -5,7 +5,6 @@ var gutil = require('gulp-util');
 var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
 var autoprefixer = require('gulp-autoprefixer');
-var nodeSass = require('node-sass');
 var cleanCSS = require('gulp-clean-css');
 var handleErrors = require('../lib/handleErrors');
 var env = require('../lib/env');

--- a/tasks/fonts.js
+++ b/tasks/fonts.js
@@ -8,7 +8,7 @@ var cookTask = require('../lib/cookTask');
 var cookTaskConfig = require('../lib/cookTaskConfig');
 
 var defaultTaskConfig = {
-  src: '.',
+  src: 'fonts',
   dest: '.'
 };
 

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -11,7 +11,7 @@ var cookTask = require('../lib/cookTask');
 var cookTaskConfig = require('../lib/cookTaskConfig');
 
 var defaultTaskConfig = {
-  src: '.',
+  src: 'images',
   dest: '.',
   npm: true
 };

--- a/tasks/resources.js
+++ b/tasks/resources.js
@@ -8,7 +8,7 @@ var cookTask = require('../lib/cookTask');
 var cookTaskConfig = require('../lib/cookTaskConfig');
 
 var defaultTaskConfig = {
-  src: '.',
+  src: 'resources',
   dest: '.'
 };
 

--- a/tasks/svgSprite.js
+++ b/tasks/svgSprite.js
@@ -11,7 +11,7 @@ var cookTask = require('../lib/cookTask');
 var cookTaskConfig = require('../lib/cookTaskConfig');
 
 var defaultTaskConfig = {
-  src: '.',
+  src: 'sprites',
   dest: '.',
   extensions: ['svg']
 };

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -10,8 +10,9 @@ var cookTask = require('../lib/cookTask');
 var cookTaskConfig = require('../lib/cookTaskConfig');
 
 var defaultTaskConfig = {
-  src: '.',
-  dest: '.'
+  src: 'javascripts',
+  dest: '.',
+  extensions: ['js']
 };
 
 module.exports = function(config) {


### PR DESCRIPTION
This PR enables the sass-loader and CSS modules in Pinion.

It also just ensures that tasks work by default, without the need for any specific overridden config

I'm aware that the addition of the sass-loader is adding to Pinion's bloat; this is something I'm dealing with separately, such that dependencies for each task/loader will live in the project consuming Pinion, making Pinion more plug & play, than kitchen-sink