### PR TITLE
Replace references to assets with CDN information in the rev-postfix …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinion-pipeline",
   "description": "An opinionated pipeline, modelled after the Rails asset pipeline. Designed for the benefits of speed, and access to CommonJS modules",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "main": "./index.js",
   "bin": {
     "pinion": "./bin/index.js"
@@ -35,6 +35,7 @@
     "gulp-imagemin": "^3.0.0",
     "gulp-json-editor": "^2.2.1",
     "gulp-notify": "^2.2.0",
+    "gulp-replace": "^0.5.4",
     "gulp-rev": "^7.0.0",
     "gulp-rev-napkin": "^0.1.0",
     "gulp-rev-replace": "^0.4.3",

--- a/tasks/revPostfix.js
+++ b/tasks/revPostfix.js
@@ -3,22 +3,36 @@
 var gulp = require('gulp');
 var path = require('path');
 var jeditor = require('gulp-json-editor');
+var replace = require('gulp-replace');
+var debug = require('../lib/gulpDebug');
 
 module.exports = function(config) {
   // Update rev manifest to include CDN information
   // This is separate from the `rev` task to stay true to build once, deploy anywhere
 
-  gulp.task('rev-postfix', function() {
+  var searchPrefix = '/assets/';
+  var cdn = process.env.ASSET_HOST;
+  var outputPrefix = (cdn ? cdn : '') + searchPrefix;
+
+  gulp.task('rev-postfix-assets', function() {
+    var searchRegex = new RegExp(
+      '([\'"])' + searchPrefix + '(?=[^\\s\'"]+[\\?\'"])',
+      'g'
+    );
+
+    return gulp.src(path.join(config.root.dest, '**/*.{css,js}'))
+      .pipe(debug({ title: 'rev-postfix-assets' }))
+      .pipe(replace(searchRegex, '$1' + outputPrefix))
+      .pipe(gulp.dest(config.root.dest));
+  });
+
+  gulp.task('rev-postfix-manifest', function() {
     return gulp.src(path.join(config.root.dest, 'rev-manifest.json'))
       .pipe(jeditor(function(json) {
         var completeKey = '__postfixComplete';
         if(json[completeKey]) {
           return json;
         }
-
-        var searchPrefix = '/assets/';
-        var cdn = process.env.ASSET_HOST;
-        var outputPrefix = (cdn ? cdn : '') + searchPrefix;
 
         var newJson = {};
         Object.keys(json).forEach(function(key) {
@@ -31,4 +45,6 @@ module.exports = function(config) {
       }))
       .pipe(gulp.dest(config.root.dest));
   });
+
+  gulp.task('rev-postfix', ['rev-postfix-assets', 'rev-postfix-manifest']);
 };


### PR DESCRIPTION
Currently we are experiencing an issue where assets that are referenced in built JS and CSS files are not actually being updated with the correct CDN information

This has not been an issue up until now, since we were depending on either the rev-manifest, or coincidental relative positioning.