### PR TITLE
Production mode error handling

### DIFF
--- a/lib/handleErrors.js
+++ b/lib/handleErrors.js
@@ -3,7 +3,11 @@
 var env = require('./env');
 
 module.exports = function(errorObject) {
-  if(env.isDevelopment()) {
+  if(env.isProduction()) {
+    console.log(errorObject);
+    process.exit(1);
+  }
+  else {
     var notify = require('gulp-notify');
     notify.onError(errorObject.toString().split(': ').join(':\n')).apply(this, arguments);
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinion-pipeline",
   "description": "An opinionated pipeline, modelled after the Rails asset pipeline. Designed for the benefits of speed, and access to CommonJS modules",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "./index.js",
   "bin": {
     "pinion": "./bin/index.js"


### PR DESCRIPTION
Currently (for some bizarre reason) the error handling logic for webpack is set to not log out build failures, when in production mode.

Obviously this logic is incorrect, so this PR adds a console log of the error object, and exits the process with exit code 1