### PR TITLE
Lock down the dependency of expose-loader to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinion-pipeline",
   "description": "An opinionated pipeline, modelled after the Rails asset pipeline. Designed for the benefits of speed, and access to CommonJS modules",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "./index.js",
   "bin": {
     "pinion": "./bin/index.js"
@@ -26,7 +26,7 @@
     "coffee-script": "^1.10.0",
     "css-loader": "^0.23.1",
     "del": "^2.2.0",
-    "expose-loader": "^0.7.1",
+    "expose-loader": "0.7.1",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-changed": "^1.3.0",


### PR DESCRIPTION
Related issue: https://github.com/webpack-contrib/expose-loader/issues/29