### PR TITLE
Handle no git

### DIFF
--- a/lib/getBuildInfo.js
+++ b/lib/getBuildInfo.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var git = require('git-rev-sync');
+
+module.exports = function(src) {
+  var buildInfo = {
+    date: new Date(),
+    short: process.env.GIT_SHORT,
+    branch: process.env.GIT_BRANCH
+  };
+
+  var buildInfoSatisfied = Object.keys(buildInfo).reduce(function(acc, key) {
+    return acc && Boolean(buildInfo[key]);
+  }, true);
+
+  if(!buildInfoSatisfied) {
+    try {
+      buildInfo.short = git.short(src);
+      buildInfo.branch = git.branch(src);
+    }
+    catch(e) {
+      console.log('No git directory found. Git-specific info being set as undefined');
+    }
+  }
+
+  return buildInfo;
+};

--- a/lib/webpackBaseConfig.js
+++ b/lib/webpackBaseConfig.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var webpack = require('webpack');
 var objectAssign = require('object-assign');
-var git = require('git-rev-sync');
+var getBuildInfo = require('./getBuildInfo');
 
 function getGlobalModulePathToAliasMap(globals) {
   var pathToAliasMap = {};
@@ -57,6 +57,7 @@ module.exports = function(taskConfig, rootConfig) {
     return '.' + extension;
   });
   var cssQueryParams = taskConfig.cssModules ? '?modules&localIdentName=[local]___[hash:base64:5]' : '';
+  var buildInfo = getBuildInfo(jsSrc);
 
   // There's a webpack bug, where (since pinion is external to where it will
   // be called from) we need to pass through resolved webpack ids, for plugins
@@ -83,9 +84,9 @@ module.exports = function(taskConfig, rootConfig) {
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-        'BUILD_DATE': JSON.stringify(git.date(jsSrc)),
-        'BUILD_HASH': JSON.stringify(git.short(jsSrc)),
-        'BUILD_BRANCH': JSON.stringify(git.branch(jsSrc))
+        'BUILD_DATE': JSON.stringify(buildInfo.date),
+        'BUILD_HASH': JSON.stringify(buildInfo.short),
+        'BUILD_BRANCH': JSON.stringify(buildInfo.branch)
       })
     ],
     output: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinion-pipeline",
   "description": "An opinionated pipeline, modelled after the Rails asset pipeline. Designed for the benefits of speed, and access to CommonJS modules",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "./index.js",
   "bin": {
     "pinion": "./bin/index.js"


### PR DESCRIPTION
A .git directory is not always present!

This fixes the issues that arise from not running from a git project, and allows a fallback of specifying these values through ENV vars