### PR TITLE
envVars

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Uses webpack to compile Javascript code
  * `globals` - a map of local npm packages to their aliases. E.g. `jquery: ['$', 'jQuery']`
  * `loaders` - config for webpack loaders to be concatted onto the default Pinion loaders. (Pinion will search your package's node_modules for any loader dependencies it can't find in its own)
  * `cssModules` - a boolean of whether you want to use CSS modules for CSS imports (excluding imports from node_modules)
+ * `envVars` - a list of the environment variables that should be accessible in the built JS files with `process.env` (`NODE_ENV` is always exposed)
 
 ### css
 

--- a/lib/webpackBaseConfig.js
+++ b/lib/webpackBaseConfig.js
@@ -47,6 +47,23 @@ function createLoadersForGlobalPackages(globalModulePathToAliasMap) {
   });
 }
 
+// we don't want ALL the ENV vars passed through, since complex builds have a lot
+// of variables - we don't want to bloat the bundle, or slow the build
+function getEnvSubset(envVars) {
+  // we must have at least an array containing the NODE_ENV
+  envVars = envVars || ['NODE_ENV'];
+  if(envVars.indexOf('NODE_ENV') === -1) {
+    envVars.push('NODE_ENV');
+  }
+
+  return envVars.reduce(function(acc, env) {
+    var newEnvObj = {};
+    newEnvObj[env] = process.env[env];
+
+    return objectAssign({}, acc, newEnvObj);
+  }, {});
+}
+
 module.exports = function(taskConfig, rootConfig) {
   var jsSrc = path.resolve(rootConfig.src, taskConfig.src);
   var jsDest = path.resolve(rootConfig.dest, taskConfig.dest);
@@ -77,13 +94,15 @@ module.exports = function(taskConfig, rootConfig) {
 
   var globalModulePathToAliasMap = getGlobalModulePathToAliasMap(globals);
 
+  var envSubset = getEnvSubset(taskConfig.envVars);
+
   var wpconfig = {
     context: jsSrc,
     entry: forceGlobalModulesRequire(entries, Object.keys(globalModulePathToAliasMap)),
     plugins: [
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
       new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        'process.env': JSON.stringify(envSubset),
         'BUILD_DATE': JSON.stringify(buildInfo.date),
         'BUILD_HASH': JSON.stringify(buildInfo.short),
         'BUILD_BRANCH': JSON.stringify(buildInfo.branch)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinion-pipeline",
   "description": "An opinionated pipeline, modelled after the Rails asset pipeline. Designed for the benefits of speed, and access to CommonJS modules",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "main": "./index.js",
   "bin": {
     "pinion": "./bin/index.js"


### PR DESCRIPTION
Add an `envVars` option to the JS task, to specify which environment variables should be exposed on `process.env` in JS files

This will allow the following:

(pinionfile)
```javascript
tasks: {
  js: {
    envVars: ['FOO'],
  },
}
```

run with the command `NODE_ENV=production FOO=1 BAR=2 pinion`

with some JS file
```javascript
console.log(process.env.NODE_ENV) // = production, since NODE_ENV is always exposed
console.log(process.env.FOO) // = 1, since FOO was specified in `envVars`
console.log(process.env.BAR) // = undefined, since BAR was not specified `envVars`
```