### PR TITLE
Allow specification of custom webpack plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Uses webpack to compile Javascript code
  * `entries` - a map of built file names, to an array of source files. E.g. `{ bundle: ['./a.js', './b.js'] }` to create a bundle.js from an a.js and b.js
  * `globals` - a map of local npm packages to their aliases. E.g. `jquery: ['$', 'jQuery']`
  * `loaders` - config for webpack loaders to be concatted onto the default Pinion loaders. (Pinion will search your package's node_modules for any loader dependencies it can't find in its own)
+ * `plugins` - config for webpack plugins to be concatted onto the default Pinion plugins. (Pinion will search your package's node_modules for any plugin dependencies it can't find in its own)
  * `cssModules` - a boolean of whether you want to use CSS modules for CSS imports (excluding imports from node_modules)
 
 ### css

--- a/lib/webpackBaseConfig.js
+++ b/lib/webpackBaseConfig.js
@@ -88,7 +88,7 @@ module.exports = function(taskConfig, rootConfig) {
         'BUILD_HASH': JSON.stringify(buildInfo.short),
         'BUILD_BRANCH': JSON.stringify(buildInfo.branch)
       })
-    ],
+    ].concat(taskConfig.plugins || []),
     output: {
       path: path.normalize(jsDest),
       filename: '[name].js',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinion-pipeline",
   "description": "An opinionated pipeline, modelled after the Rails asset pipeline. Designed for the benefits of speed, and access to CommonJS modules",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "main": "./index.js",
   "bin": {
     "pinion": "./bin/index.js"


### PR DESCRIPTION
We already allow custom loaders, but currently not custom plugins. This PR brings the same functionality to plugins.