### PR TITLE
DefinePlugin + UglifyJS weirdness

### DIFF
--- a/lib/webpackBaseConfig.js
+++ b/lib/webpackBaseConfig.js
@@ -95,18 +95,21 @@ module.exports = function(taskConfig, rootConfig) {
   var globalModulePathToAliasMap = getGlobalModulePathToAliasMap(globals);
 
   var envSubset = getEnvSubset(taskConfig.envVars);
+  var defineOptions = {
+    'BUILD_DATE': JSON.stringify(buildInfo.date),
+    'BUILD_HASH': JSON.stringify(buildInfo.short),
+    'BUILD_BRANCH': JSON.stringify(buildInfo.branch)
+  };
+  Object.keys(envSubset).forEach(function(envKey) {
+    defineOptions['process.env.' + envKey] = JSON.stringify(envSubset[envKey]);
+  });
 
   var wpconfig = {
     context: jsSrc,
     entry: forceGlobalModulesRequire(entries, Object.keys(globalModulePathToAliasMap)),
     plugins: [
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-      new webpack.DefinePlugin({
-        'process.env': JSON.stringify(envSubset),
-        'BUILD_DATE': JSON.stringify(buildInfo.date),
-        'BUILD_HASH': JSON.stringify(buildInfo.short),
-        'BUILD_BRANCH': JSON.stringify(buildInfo.branch)
-      })
+      new webpack.DefinePlugin(defineOptions)
     ].concat(taskConfig.plugins || []),
     output: {
       path: path.normalize(jsDest),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinion-pipeline",
   "description": "An opinionated pipeline, modelled after the Rails asset pipeline. Designed for the benefits of speed, and access to CommonJS modules",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "main": "./index.js",
   "bin": {
     "pinion": "./bin/index.js"
@@ -61,7 +61,7 @@
     "semver": "^5.1.0",
     "style-loader": "^0.13.1",
     "tildify": "^1.2.0",
-    "webpack": "^1.13.2"
+    "webpack": "^1.14.0"
   },
   "devDependencies": {
     "gulp-jshint": "^2.0.1",


### PR DESCRIPTION
This PR specifies the `process.env` vars to `DefinePlugin` as `process.env.X: JSON.stringify('y')` rather than `process.env: JSON.stringify({ X: 'y' })`, as the latter has negative implications on minification

Namely, the following doesn't actually minify out properly

```
if({ NODE_ENV: 'production' }.NODE_ENV !== 'production') {
  // some block that clearly won't be run
}
```

whereas the following does

```
if('production' !== 'production') {
  // some block that clearly won't be run
}
```

so we need to make sure to specify the env vars in our `DefinePlugin` correctly